### PR TITLE
Added functionality to Delete a tag.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
+
 namespace adoAdmin
 {
     public class Program
@@ -454,6 +455,32 @@ namespace adoAdmin
 
                     if (table.Rows .Count > 0 ) { table.Write(); } else { Console.WriteLine(" No empty tags found"); }
                     
+                    Console.WriteLine();
+                }
+
+                // Delete a tag 
+                if (action == "deletetag")
+                {
+                    Console.Write("Deleting tag: ");
+
+                    try
+                    {
+                        Repos.Tags.DeleteTag(vssConnection, project, name);
+
+                        Console.WriteLine($"Tag: " + name + " deleted successfully.");
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"Failed to delete tag: " + name + ".");
+                        if ( e.InnerException is null )
+                        {
+                            Console.WriteLine(e.Message);
+                        }
+                        else
+                        {
+                            Console.WriteLine(e.InnerException.Message);
+                        }
+                    }
                     Console.WriteLine();
                 }
 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,8 @@ Find all the tags that are not used and can be deleted.
 ```
 adoadmin.exe /org:{organization name} /pat:{value} /action:listemptytags /project:{project name}
 ```
+
+Delete a specific tag in a project.
+```
+adoadmin.exe /org:{organization name} /pat:{value} /action:deletetag /project:{project name} /name:{tag name}
+```

--- a/Repos/Tags.cs
+++ b/Repos/Tags.cs
@@ -43,6 +43,26 @@ namespace adoAdmin.Repos
 
             return wits.WorkItems.ToList();
         }
+        public static void DeleteTag(VssConnection connection, string project, string name)
+        {
+            WorkItemTrackingHttpClient workItemTrackingClient = connection.GetClient<WorkItemTrackingHttpClient>();
+             
+            List<WorkItemTagDefinition> tags = workItemTrackingClient.GetTagsAsync(project).Result;
+            
+            WorkItemTagDefinition specificTag = tags.FirstOrDefault(tag => tag.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            //if the tag exists delete it
+            if (specificTag != null)
+            {
+                workItemTrackingClient.DeleteTagAsync(project, specificTag.Name).SyncResult();
+            }
+            //If the tag doesn't exist throw an error we can catch to make this case work the same as a TF error or other lower level issues.
+            else
+            {
+                throw new Exception("TagNotFound:  The following tag does not exist: " + name + ". Verify that the name of the project is correct and that the tag exists on the specified project.");
+            }
+
+        }
+
     }    
 }
 


### PR DESCRIPTION
Since the automatic tag removal is unreliable to remove an empty tag after 3 days, I added this to help the edge case customer's that cannot install the tags extension in their orgs/instances.

it determines if the tag exists because if you attempt to delete a tag that does not exists it looks identical to a success.

if it exists, it removes the tag, 
if not, it lets the user know the tag does not exist. 
on a failure due to exception, it curates the error generated to just the message.  

this seems like a lower bar for some users than running a PowerShell script to accomplish the same goal.